### PR TITLE
Issue #14 - Update EntrypointList.vue

### DIFF
--- a/web/src/components/EntrypointList.vue
+++ b/web/src/components/EntrypointList.vue
@@ -58,7 +58,7 @@ export default {
         },
         {
           key: "type",
-          label: "Type",
+          label: "Standard",
           thClass: ".col-field-styling",
           thStyle: { width: "87px" }
         },


### PR DESCRIPTION
Issue #14 - The Unit Type Label is set to "Standard." The "Definition" column was already changed to "Description."