### PR TITLE
Issue #26

### DIFF
--- a/web/src/components/EntrypointList.vue
+++ b/web/src/components/EntrypointList.vue
@@ -58,7 +58,7 @@ export default {
         },
         {
           key: "type",
-          label: "Type",
+          label: "Standard",
           thClass: ".col-field-styling",
           thStyle: { width: "87px" }
         },

--- a/web/src/components/Navbar.vue
+++ b/web/src/components/Navbar.vue
@@ -36,7 +36,7 @@
                 <router-link :to="{ name: 'units' }" class="nav-link">Units</router-link>
             </li>
             <li class="nav-item">
-                <router-link :to="{ name: 'references' }" class="nav-link">References</router-link>
+                <router-link :to="{ name: 'glossary' }" class="nav-link">Glossary</router-link>
             </li>
             <li class="nav-item">
                 <router-link :to="{ name: 'about' }" class="nav-link">About</router-link>

--- a/web/src/router.js
+++ b/web/src/router.js
@@ -52,8 +52,8 @@ export default new Router({
        component: UnitsPage
      },
      {
-       path: "/references",
-       name: "references",
+       path: "/glossary",
+       name: "glossary",
        component: ReferencesPage
      },
      {


### PR DESCRIPTION
Issue #26 - The page name and label in the navigation bar now are "glossary" and "Glossary" respectively.